### PR TITLE
Annotation for ProductTrait

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ return [
 ### Step 3: Configure the plugin
 
 ```yaml
-# config/services.yml
+# config/packages/loevgaard_sylius_brand.yaml
 
 imports:
     # ...
@@ -48,24 +48,10 @@ imports:
 ```
 
 ```yaml
-# config/routing.yml
+# config/routes/loevgaard_sylius_brand.yaml
 
 loevgaard_sylius_brand:
     resource: "@LoevgaardSyliusBrandPlugin/Resources/config/routing.yml"
-```
-
-```yaml
-# config/doctrine/Product.orm.yml
-
-AppBundle\Entity\Product:
-    type: entity
-    table: sylius_product
-    manyToOne:
-        brand:
-            targetEntity: Loevgaard\SyliusBrandPlugin\Entity\Brand
-            joinColumn:
-                name: brand_id
-                referencedColumnName: id
 ```
 
 ### Step 4: Import product trait
@@ -76,12 +62,17 @@ AppBundle\Entity\Product:
 
 declare(strict_types=1);
 
-namespace AppBundle\Entity;
+namespace App\Entity;
 
+use Doctrine\ORM\Mapping as ORM;
 use Loevgaard\SyliusBrandPlugin\Entity\BrandAwareInterface;
 use Loevgaard\SyliusBrandPlugin\Entity\ProductTrait;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 
+/**
+ * @ORM\MappedSuperclass()
+ * @ORM\Table(name="sylius_product")
+ */
 class Product extends BaseProduct implements BrandAwareInterface
 {
     use ProductTrait;
@@ -90,7 +81,7 @@ class Product extends BaseProduct implements BrandAwareInterface
 }
 ```
 
-**NOTE:** If you haven't extended the `Product` entity yet, follow the [customization instructions](https://docs.sylius.com/en/1.2/customization/model.html) first because you need to add a bit more configuration.
+**NOTE:** If you haven't extended the `Product` entity yet, follow the [customization instructions](https://docs.sylius.com/en/1.3/customization/model.html) first because you need to add a bit more configuration.
 
 ### Step 5: Update your database schema
 ```bash

--- a/src/Entity/ProductTrait.php
+++ b/src/Entity/ProductTrait.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Loevgaard\SyliusBrandPlugin\Entity;
 
+use Doctrine\ORM\Mapping as ORM;
+
 trait ProductTrait
 {
     /**
      * @var BrandInterface|null
+     * @ORM\ManyToOne(targetEntity="Loevgaard\SyliusBrandPlugin\Entity\Brand")
+     * @ORM\JoinColumn(name="brand_id", referencedColumnName="id")
      */
     protected $brand;
 


### PR DESCRIPTION
Instead of using `yaml` file for `src` sources we have to use Doctrine `annotation` in `ProductTrait` to allow doctrine sf4 project default configuration to be used.

Also, for sf>=3.2 projects the configuration files for `configs` and `routes` have to be put in a single file. So I update the `README.md` to handle it.