### PR TITLE
Allowing BrandImage to be overriden

### DIFF
--- a/src/Resources/config/doctrine/model/Brand.orm.xml
+++ b/src/Resources/config/doctrine/model/Brand.orm.xml
@@ -10,7 +10,7 @@
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
-        <one-to-many field="images" target-entity="Loevgaard\SyliusBrandPlugin\Model\BrandImage" mapped-by="owner" orphan-removal="true">
+        <one-to-many field="images" target-entity="Loevgaard\SyliusBrandPlugin\Model\BrandImageInterface" mapped-by="owner" orphan-removal="true">
             <cascade>
                 <cascade-all/>
             </cascade>


### PR DESCRIPTION
At the moment, if you override BrandImage, you can no more upload images because the Form is expecting Loevgaard\BrandImage and not App\BrandImage. Changing to Interface solves it.