### PR TITLE
Update Twig template and event dispatch order

### DIFF
--- a/src/Menu/BrandFormMenuBuilder.php
+++ b/src/Menu/BrandFormMenuBuilder.php
@@ -66,8 +66,8 @@ final class BrandFormMenuBuilder
             );
         } else {
             $this->eventDispatcher->dispatch(
-                self::EVENT_NAME,
-                new BrandMenuBuilderEvent($this->factory, $menu, $options['brand'])
+                new BrandMenuBuilderEvent($this->factory, $menu, $options['brand']),
+                self::EVENT_NAME
             );
         }
 

--- a/src/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Resources/views/Form/imagesTheme.html.twig
@@ -1,14 +1,17 @@
 {% extends '@SyliusUi/Form/imagesTheme.html.twig' %}
 
 {% block loevgaard_sylius_brand_brand_image_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         <div class="ui upload box segment">
             {{ form_row(form.type) }}
             {% if form.vars.value.path|default(null) is null %}
-                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
+                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i
+                        class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
             {% else %}
-                <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
-                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
+                <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}"
+                     alt="{{ form.vars.value.type }}"/>
+                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i
+                        class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
             {% endif %}
             <div class="ui hidden element">
                 {{ form_widget(form.file) }}
@@ -17,5 +20,5 @@
                 {{- form_errors(form.file) -}}
             </div>
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}


### PR DESCRIPTION
Updated imagesTheme.html.twig to use 'apply spaceless' for better readability. Altered the HTML layout for cleaner, more maintainable code.

In BrandFormMenuBuilder.php, switched the order of arguments in the event dispatch call to adhere to Symfony expected parameters order. This improves code consistency and follows Symfony's convention.