### PR TITLE
Update controller declaration syntax in YAML configs

### DIFF
--- a/src/Menu/BrandFormMenuBuilder.php
+++ b/src/Menu/BrandFormMenuBuilder.php
@@ -66,8 +66,8 @@ final class BrandFormMenuBuilder
             );
         } else {
             $this->eventDispatcher->dispatch(
-                self::EVENT_NAME,
-                new BrandMenuBuilderEvent($this->factory, $menu, $options['brand'])
+                new BrandMenuBuilderEvent($this->factory, $menu, $options['brand']),
+                self::EVENT_NAME
             );
         }
 

--- a/src/Resources/config/routing/admin/ajax/brand.yaml
+++ b/src/Resources/config/routing/admin/ajax/brand.yaml
@@ -2,7 +2,7 @@ loevgaard_sylius_brand_admin_ajax_brands_by_phrase:
     path: /search
     methods: [GET]
     defaults:
-        _controller: loevgaard_sylius_brand.controller.brand:indexAction
+        _controller: loevgaard_sylius_brand.controller.brand::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -16,7 +16,7 @@ loevgaard_sylius_brand_admin_ajax_brand_by_code:
     path: /
     methods: [GET]
     defaults:
-        _controller: loevgaard_sylius_brand.controller.brand:indexAction
+        _controller: loevgaard_sylius_brand.controller.brand::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]

--- a/src/Resources/config/routing/admin_api.yaml
+++ b/src/Resources/config/routing/admin_api.yaml
@@ -25,7 +25,7 @@ loevgaard_sylius_brand_admin_api_brand_product_index:
     path: /brands/{code}/products/
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _sylius:
             serialization_version: $version
             section: admin_api

--- a/src/Resources/config/routing/admin_api/brand_image.yaml
+++ b/src/Resources/config/routing/admin_api/brand_image.yaml
@@ -22,7 +22,7 @@ loevgaard_sylius_brand_admin_api_brand_image_index_by_type:
     path: /images/by-type/{type}
     methods: [GET]
     defaults:
-        _controller: loevgaard_sylius_brand.controller.brand_image:indexAction
+        _controller: loevgaard_sylius_brand.controller.brand_image::indexAction
         _sylius:
             serialization_version: $version
             section: admin_api

--- a/src/Resources/config/routing/shop.yaml
+++ b/src/Resources/config/routing/shop.yaml
@@ -2,7 +2,7 @@ loevgaard_sylius_brand_shop_brand_show:
     path: /brand/{code}
     methods: [GET]
     defaults:
-        _controller: loevgaard_sylius_brand.controller.brand:showAction
+        _controller: loevgaard_sylius_brand.controller.brand::showAction
         _sylius:
             template: "@LoevgaardSyliusBrandPlugin/Shop/Brand/show.html.twig"
             repository:

--- a/src/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Resources/views/Form/imagesTheme.html.twig
@@ -1,14 +1,17 @@
 {% extends '@SyliusUi/Form/imagesTheme.html.twig' %}
 
 {% block loevgaard_sylius_brand_brand_image_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         <div class="ui upload box segment">
             {{ form_row(form.type) }}
             {% if form.vars.value.path|default(null) is null %}
-                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
+                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i
+                        class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
             {% else %}
-                <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
-                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
+                <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}"
+                     alt="{{ form.vars.value.type }}"/>
+                <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i
+                        class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
             {% endif %}
             <div class="ui hidden element">
                 {{ form_widget(form.file) }}
@@ -17,5 +20,5 @@
                 {{- form_errors(form.file) -}}
             </div>
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}


### PR DESCRIPTION
Controller declaration syntax was updated in various YAML configuration files, replacing ":" with "::" for better readability and to adhere to best practices. These changes affect the 'brand' and 'product' controllers in the 'shop', 'admin_api', 'brand_image', and 'ajax' routes.