### PR TITLE
[TWIG] The spaceless tag is deprecated use filter instead

### DIFF
--- a/src/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Resources/views/Form/imagesTheme.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusUi/Form/imagesTheme.html.twig' %}
 
 {% block loevgaard_sylius_brand_brand_image_widget %}
-    {% spaceless %}
+    {% apply spaceless %}
         <div class="ui upload box segment">
             {{ form_row(form.type) }}
             {% if form.vars.value.path|default(null) is null %}
@@ -17,5 +17,5 @@
                 {{- form_errors(form.file) -}}
             </div>
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock %}


### PR DESCRIPTION
The spaceless filter was added in Twig 2.7.

Using Sylius 1.12.14 and going to the URL `/admin/brands/new` you will get this error without this PR:

> Unexpected "spaceless" tag (expecting closing tag for the "block" tag defined near line 4).

![image](https://github.com/loevgaard/SyliusBrandPlugin/assets/861820/740e8892-ecbd-40a9-9d5e-e8b96bc4cd82)

Maybe spaceless can be also removed, or we can use Twig whitespace control:
https://twig.symfony.com/doc/2.x/templates.html#whitespace-control
WDTY @loevgaard ?
