### PR TITLE
fix(form): product_type_extension class fqdn

### DIFF
--- a/src/Resources/config/services/form.xml
+++ b/src/Resources/config/services/form.xml
@@ -23,7 +23,7 @@
         </service>
 
         <service id="loevgaard_sylius_brand.form.extension.type.api_product"
-                 class="Loevgaard\SyliusBrandPlugin\Form\Extension\Api\ProductTypeExtension">
+                 class="Loevgaard\SyliusBrandPlugin\Form\Extension\ProductTypeExtension">
             <argument>%loevgaard_sylius_brand.model.brand.class%</argument>
 
             <tag name="form.type_extension"/>


### PR DESCRIPTION
See files https://github.com/loevgaard/SyliusBrandPlugin/tree/3.x/src/Form/Extension, API folder dont exist any more.